### PR TITLE
Fix mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ $ Successfully created Lerna files
 #### --independent, -i
 
 ```sh
-$ lerna publish --independent
+$ lerna init --independent
 ```
 
 This flag tells Lerna to use independent versioning mode.


### PR DESCRIPTION
Fixed the confusing command example in the init chapter of README.